### PR TITLE
Fix for Issue #2 - Allow session token persistence and renewal

### DIFF
--- a/Nuget/CreateNugetPackage.bat
+++ b/Nuget/CreateNugetPackage.bat
@@ -1,1 +1,0 @@
-nuget pack ..\Source\MediaFireSDK\MediaFireSDK.csproj -Prop Configuration=Release

--- a/Source/MediaFireSDK.Tests/MediaFireAgentTests.cs
+++ b/Source/MediaFireSDK.Tests/MediaFireAgentTests.cs
@@ -1,0 +1,468 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MediaFireSDK.Core;
+using MediaFireSDK.Model;
+using MediaFireSDK.Model.Errors;
+using MediaFireSDK.Model.Responses;
+
+namespace MediaFireSDK.Tests
+{
+    [TestClass]
+    public class MediaFireAgentTests
+    {
+        private const string AppId = "";
+        private const string AppKey = "";
+
+        private const string Email = "";
+        private const string Password = "";
+
+        private AuthenticationContext PrepareAuthenticationContest(MediaFireApiConfiguration config)
+        {
+            var authenticationContext = default(AuthenticationContext);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password, TokenVersion.V2).Wait();
+
+                authenticationContext = agent.User.GetAuthenticationContext();
+            }
+
+            Assert.IsNotNull(authenticationContext, "Authentication context is null");
+
+            return authenticationContext;
+        }
+
+        [TestMethod]
+        public void GetSessionToken_Version1_Succeeds()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            var token = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                token = agent.User.GetSessionToken(Email, Password).Result;
+            }
+
+            Assert.IsNotNull(token, "SessionToken v1 is null");
+        }
+
+        [TestMethod]
+        public void GetSessionToken_Version2_Succeeds()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            var token = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                token = agent.User.GetSessionToken(Email, Password, TokenVersion.V2).Result;
+            }
+
+            Assert.IsNotNull(token, "SessionToken v2 is null");
+        }
+
+        [TestMethod]
+        public void GetFilesAndFolders_WithSessionToken_Version1_Succeeds()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            IList<MediaFireFolder> folders;
+            IList<MediaFireFile> files;
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password).Wait();
+
+                folders = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Folders.ToApiParameter() }
+                }).Result.FolderContent.Folders;
+
+                files = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Files.ToApiParameter() }
+                }).Result.FolderContent.Files;
+            }
+
+            Assert.IsNotNull(folders, "Returned folders collection is null");
+            Assert.AreNotEqual(0, folders.Count, "No folders found");
+            Assert.IsNotNull(files, "Returned files collection is null");
+            Assert.AreNotEqual(0, files.Count, "No files found");
+        }
+
+        [TestMethod]
+        public void GetFilesAndFolders_WithSessionToken_Version2_Succeeds()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            IList<MediaFireFolder> folders;
+            IList<MediaFireFile> files;
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password, TokenVersion.V2).Wait();
+
+                folders = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Folders.ToApiParameter() }
+                }).Result.FolderContent.Folders;
+
+                files = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Files.ToApiParameter() }
+                }).Result.FolderContent.Files;
+            }
+
+            Assert.IsNotNull(folders, "Returned folders collection is null");
+            Assert.AreNotEqual(0, folders.Count, "No folders found");
+            Assert.IsNotNull(files, "Returned files collection is null");
+            Assert.AreNotEqual(0, files.Count, "No files found");
+        }
+
+        [TestMethod]
+        public void GetFilesAndFolders_WithRestoredSessionToken_Version2_Succeeds()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            var authenticationContext = PrepareAuthenticationContest(config);
+
+            IList<MediaFireFolder> folders;
+            IList<MediaFireFile> files;
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.SetAuthenticationContext(authenticationContext);
+
+                folders = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Folders.ToApiParameter() }
+                }).Result.FolderContent.Folders;
+
+                files = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Files.ToApiParameter() }
+                }).Result.FolderContent.Files;
+            }
+
+            Assert.IsNotNull(folders, "Returned folders collection is null");
+            Assert.AreNotEqual(0, folders.Count, "No folders found");
+            Assert.IsNotNull(files, "Returned files collection is null");
+            Assert.AreNotEqual(0, files.Count, "No files found");
+        }
+
+        private void DeleteFolderByPath(IMediaFireAgent agent, string folderPath, bool ignoreErrors = false)
+        {
+            try
+            {
+                agent.GetAsync<MediaFireEmptyResponse>(MediaFireApiFolderMethods.Delete, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.FolderPath, folderPath }
+                }).Wait();
+            }
+            catch (AggregateException ex)
+            {
+                if (!ignoreErrors || ex.InnerExceptions.Count != 1 || !(ex.InnerExceptions[0] is MediaFireApiException))
+                    throw;
+            }
+        }
+
+        [TestMethod]
+        public void CreateFolder_WithSessionToken_Version1_Succeeds()
+        {
+            const string folderName = "MediaFireSDKTestFolder";
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            var folderKey = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password).Wait();
+
+                DeleteFolderByPath(agent, Path.AltDirectorySeparatorChar + folderName, true);
+
+                folderKey = agent.GetAsync<MediaFireCreateFolderResponse>(MediaFireApiFolderMethods.Create, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.ParentKey, string.Empty },
+                    { MediaFireApiParameters.FolderName, folderName }
+                }).Result.FolderKey;
+
+                DeleteFolderByPath(agent, Path.AltDirectorySeparatorChar + folderName);
+            }
+
+            Assert.IsFalse(string.IsNullOrEmpty(folderKey), "Folder creation failed");
+        }
+
+        [TestMethod]
+        public void CreateFolder_WithRestoredSessionToken_Version2_Succeeds()
+        {
+            const string folderName = "MediaFireSDKTestFolder";
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            var authenticationContext = PrepareAuthenticationContest(config);
+
+            var folderKey = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.SetAuthenticationContext(authenticationContext);
+
+                DeleteFolderByPath(agent, Path.AltDirectorySeparatorChar + folderName, true);
+
+                folderKey = agent.GetAsync<MediaFireCreateFolderResponse>(MediaFireApiFolderMethods.Create, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.ParentKey, string.Empty },
+                    { MediaFireApiParameters.FolderName, folderName }
+                }).Result.FolderKey;
+
+                DeleteFolderByPath(agent, Path.AltDirectorySeparatorChar + folderName);
+            }
+
+            Assert.IsFalse(string.IsNullOrEmpty(folderKey), "Folder creation failed");
+        }
+
+        private void DeleteFileByPath(IMediaFireAgent agent, string filePath, bool ignoreErrors = false)
+        {
+            try
+            {
+                agent.GetAsync<MediaFireEmptyResponse>(MediaFireApiFileMethods.Delete, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.FilePath, filePath }
+                }).Wait();
+            }
+            catch (AggregateException ex)
+            {
+                if (!ignoreErrors || ex.InnerExceptions.Count != 1 || !(ex.InnerExceptions[0] is MediaFireApiException))
+                    throw;
+            }
+        }
+
+        [TestMethod]
+        public void CreateFile_WithSessionToken_Version1_Succeeds()
+        {
+            const string fileName = "MediaFireSDKTestFile.ext";
+
+            var content = Enumerable.Range(0, 20).Select(i => (byte)i).ToArray();
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey, useHttpV1: true);
+
+            var authenticationContext = PrepareAuthenticationContest(config);
+
+            var fileKey = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password).Wait();
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName, true);
+
+                using (var contentStream = new MemoryStream(content))
+                {
+                    var uploadConfig = agent.Upload.GetUploadConfiguration(fileName, contentStream.Length, string.Empty, MediaFireActionOnDuplicate.Skip).Result;
+                    var upload = agent.Upload.Simple(uploadConfig, contentStream, null).Result;
+
+                    while (!(upload.IsComplete && upload.IsSuccess))
+                    {
+                        Task.Delay(100).Wait();
+                        upload = agent.Upload.PollUpload(upload.Key).Result;
+                    }
+
+                    fileKey = agent.GetAsync<MediaFireGetFileInfoResponse>(MediaFireApiFileMethods.GetInfo, new Dictionary<string, object>() {
+                        { MediaFireApiParameters.QuickKey, upload.QuickKey }
+                    }).Result.FileInfo.Key;
+                }
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName);
+            }
+
+            Assert.IsFalse(string.IsNullOrEmpty(fileKey), "File creation failed");
+        }
+
+        [TestMethod]
+        public void CreateFile_WithRestoredSessionToken_Version2_Succeeds()
+        {
+            const string fileName = "MediaFireSDKTestFile.ext";
+
+            var content = Enumerable.Range(0, 20).Select(i => (byte)i).ToArray();
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey, useHttpV1: true);
+
+            var authenticationContext = PrepareAuthenticationContest(config);
+
+            var fileKey = default(string);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.SetAuthenticationContext(authenticationContext);
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName, true);
+
+                using (var contentStream = new MemoryStream(content))
+                {
+                    var uploadConfig = agent.Upload.GetUploadConfiguration(fileName, contentStream.Length, string.Empty, MediaFireActionOnDuplicate.Skip).Result;
+                    var upload = agent.Upload.Simple(uploadConfig, contentStream, null).Result;
+
+                    while (!(upload.IsComplete && upload.IsSuccess))
+                    {
+                        Task.Delay(100).Wait();
+                        upload = agent.Upload.PollUpload(upload.Key).Result;
+                    }
+
+                    fileKey = agent.GetAsync<MediaFireGetFileInfoResponse>(MediaFireApiFileMethods.GetInfo, new Dictionary<string, object>() {
+                        { MediaFireApiParameters.QuickKey, upload.QuickKey }
+                    }).Result.FileInfo.Key;
+                }
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName);
+            }
+
+            Assert.IsFalse(string.IsNullOrEmpty(fileKey), "File creation failed");
+        }
+
+        [TestMethod]
+        public void DownloadFile_WithSessionToken_Version1_Succeeds()
+        {
+            const string fileName = "MediaFireSDKTestFile.ext";
+
+            var content = Enumerable.Range(0, 20).Select(i => (byte)i).ToArray();
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey, useHttpV1: true);
+
+            var result = default(byte[]);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password).Wait();
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName, true);
+
+                var fileKey = default(string);
+                using (var contentStream = new MemoryStream(content))
+                {
+                    var uploadConfig = agent.Upload.GetUploadConfiguration(fileName, contentStream.Length, string.Empty, MediaFireActionOnDuplicate.Skip).Result;
+                    var upload = agent.Upload.Simple(uploadConfig, contentStream, null).Result;
+
+                    while (!(upload.IsComplete && upload.IsSuccess))
+                    {
+                        Task.Delay(100).Wait();
+                        upload = agent.Upload.PollUpload(upload.Key).Result;
+                    }
+
+                    fileKey = agent.GetAsync<MediaFireGetFileInfoResponse>(MediaFireApiFileMethods.GetInfo, new Dictionary<string, object>() {
+                        { MediaFireApiParameters.QuickKey, upload.QuickKey }
+                    }).Result.FileInfo.Key;
+                }
+
+                var links = agent.GetAsync<MediaFireGetLinksResponse>(MediaFireApiFileMethods.GetLinks, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.QuickKey, fileKey },
+                    { MediaFireApiParameters.LinkType, MediaFireApiConstants.LinkTypeDirectDownload }
+                }).Result;
+
+                if (!links.Links.Any() && string.IsNullOrEmpty(links.Links[0].DirectDownload))
+                    throw new MediaFireException(MediaFireErrorMessages.FileMustContainADirectLink);
+
+                var response = new HttpClient().SendAsync(new HttpRequestMessage(HttpMethod.Get, links.Links[0].DirectDownload), HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).Result;
+                response.EnsureSuccessStatusCode();
+
+                var resultStream = response.Content.ReadAsStreamAsync().Result;
+                var bufferStream = new MemoryStream();
+                resultStream.CopyToAsync(bufferStream).Wait();
+
+                result = bufferStream.GetBuffer().Take((int)bufferStream.Length).ToArray();
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName);
+            }
+
+            Assert.IsNotNull(result, "File creation failed");
+            CollectionAssert.AreEqual(content, result, "File content mismatch");
+        }
+
+        [TestMethod]
+        public void DownloadFile_WithRestoredSessionToken_Version2_Succeeds()
+        {
+            const string fileName = "MediaFireSDKTestFile.ext";
+
+            var content = Enumerable.Range(0, 20).Select(i => (byte)i).ToArray();
+
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey, useHttpV1: true);
+
+            var authenticationContext = PrepareAuthenticationContest(config);
+
+            var result = default(byte[]);
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.SetAuthenticationContext(authenticationContext);
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName, true);
+
+                var fileKey = default(string);
+                using (var contentStream = new MemoryStream(content))
+                {
+                    var uploadConfig = agent.Upload.GetUploadConfiguration(fileName, contentStream.Length, string.Empty, MediaFireActionOnDuplicate.Skip).Result;
+                    var upload = agent.Upload.Simple(uploadConfig, contentStream, null).Result;
+
+                    while (!(upload.IsComplete && upload.IsSuccess))
+                    {
+                        Task.Delay(100).Wait();
+                        upload = agent.Upload.PollUpload(upload.Key).Result;
+                    }
+
+                    fileKey = agent.GetAsync<MediaFireGetFileInfoResponse>(MediaFireApiFileMethods.GetInfo, new Dictionary<string, object>() {
+                        { MediaFireApiParameters.QuickKey, upload.QuickKey }
+                    }).Result.FileInfo.Key;
+                }
+
+                var links = agent.GetAsync<MediaFireGetLinksResponse>(MediaFireApiFileMethods.GetLinks, new Dictionary<string, object>() {
+                    { MediaFireApiParameters.QuickKey, fileKey },
+                    { MediaFireApiParameters.LinkType, MediaFireApiConstants.LinkTypeDirectDownload }
+                }).Result;
+
+                if (!links.Links.Any() && string.IsNullOrEmpty(links.Links[0].DirectDownload))
+                    throw new MediaFireException(MediaFireErrorMessages.FileMustContainADirectLink);
+
+                var response = new HttpClient().SendAsync(new HttpRequestMessage(HttpMethod.Get, links.Links[0].DirectDownload), HttpCompletionOption.ResponseHeadersRead, CancellationToken.None).Result;
+                response.EnsureSuccessStatusCode();
+
+                var resultStream = response.Content.ReadAsStreamAsync().Result;
+                var bufferStream = new MemoryStream();
+                resultStream.CopyToAsync(bufferStream).Wait();
+
+                result = bufferStream.GetBuffer().Take((int)bufferStream.Length).ToArray();
+
+                DeleteFileByPath(agent, Path.AltDirectorySeparatorChar + fileName);
+            }
+
+            Assert.IsNotNull(result, "File creation failed");
+            CollectionAssert.AreEqual(content, result, "File content mismatch");
+        }
+
+        [TestMethod]
+        public void RenewSecrectKey_RaisesEvent()
+        {
+            var config = new MediaFireApiConfiguration(appId: AppId, apiKey: AppKey);
+
+            int eventRaised = 0;
+
+            IList<MediaFireFolder> folders;
+            IList<MediaFireFile> files;
+            using (var agent = new MediaFireAgent(config))
+            {
+                agent.User.GetSessionToken(Email, Password, TokenVersion.V2).Wait();
+                agent.User.AuthenticationContextChanged += (s, e) => ++eventRaised;
+
+                folders = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Folders.ToApiParameter() }
+                }).Result.FolderContent.Folders;
+
+                files = agent.GetAsync<MediaFireGetContentResponse>(MediaFireApiFolderMethods.GetContent, new Dictionary<string, object>
+                {
+                    { MediaFireApiParameters.FolderKey, string.Empty },
+                    { MediaFireApiParameters.ContentType, MediaFireFolderContentType.Files.ToApiParameter() }
+                }).Result.FolderContent.Files;
+            }
+
+            Assert.AreEqual(2, eventRaised, "AuthenticationContextChange event not raised");
+        }
+    }
+}

--- a/Source/MediaFireSDK.Tests/MediaFireSDK.Tests.csproj
+++ b/Source/MediaFireSDK.Tests/MediaFireSDK.Tests.csproj
@@ -1,0 +1,125 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{63127548-777F-4697-BDF9-9B270029E1FC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MediaFireSDK.Tests</RootNamespace>
+    <AssemblyName>MediaFireSDK.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942, processorArchitecture=MSIL">
+      <HintPath>..\packages\Portable.BouncyCastle.1.8.1\lib\net45\crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="MediaFireAgentTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MediaFireSDK\MediaFireSDK.csproj">
+      <Project>{70c8fead-150f-4cb6-aadf-91f2b4613f9f}</Project>
+      <Name>MediaFireSDK</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>Dieses Projekt verweist auf mindestens ein NuGet-Paket, das auf diesem Computer fehlt. Verwenden Sie die Wiederherstellung von NuGet-Paketen, um die fehlenden Dateien herunterzuladen. Weitere Informationen finden Sie unter "http://go.microsoft.com/fwlink/?LinkID=322105". Die fehlende Datei ist "{0}".</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/MediaFireSDK.Tests/Properties/AssemblyInfo.cs
+++ b/Source/MediaFireSDK.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über folgende 
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("MediaFireSDK.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MediaFireSDK.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Wenn ComVisible auf "false" festgelegt wird, sind die Typen innerhalb dieser Assembly 
+// für COM-Komponenten unsichtbar.  Wenn Sie auf einen Typ in dieser Assembly von 
+// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("63127548-777f-4697-bdf9-9b270029e1fc")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion 
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
+// übernehmen, indem Sie "*" eingeben:
+// [Assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/MediaFireSDK.Tests/app.config
+++ b/Source/MediaFireSDK.Tests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.29.0" newVersion="4.2.29.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/MediaFireSDK.Tests/packages.config
+++ b/Source/MediaFireSDK.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Portable.BouncyCastle" version="1.8.1" targetFramework="net45" />
+</packages>

--- a/Source/MediaFireSDK.sln
+++ b/Source/MediaFireSDK.sln
@@ -1,16 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaFireSDK", "MediaFireSDK\MediaFireSDK.csproj", "{70C8FEAD-150F-4CB6-AADF-91F2B4613F9F}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{7C0CBE58-6C67-419B-AA37-7326ACA90847}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\NuGet.Config = .nuget\NuGet.Config
-		.nuget\NuGet.exe = .nuget\NuGet.exe
-		.nuget\NuGet.targets = .nuget\NuGet.targets
-	EndProjectSection
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MediaFireSDK.Tests", "MediaFireSDK.Tests\MediaFireSDK.Tests.csproj", "{63127548-777F-4697-BDF9-9B270029E1FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,6 +17,10 @@ Global
 		{70C8FEAD-150F-4CB6-AADF-91F2B4613F9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{70C8FEAD-150F-4CB6-AADF-91F2B4613F9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{70C8FEAD-150F-4CB6-AADF-91F2B4613F9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63127548-777F-4697-BDF9-9B270029E1FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63127548-777F-4697-BDF9-9B270029E1FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63127548-777F-4697-BDF9-9B270029E1FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63127548-777F-4697-BDF9-9B270029E1FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/MediaFireSDK/Core/AuthenticationContext.cs
+++ b/Source/MediaFireSDK/Core/AuthenticationContext.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace MediaFireSDK.Core
+{
+    public class AuthenticationContext
+    {
+        public string SessionToken { get; }
+
+        public long SecretKey { get; }
+
+        public string Time { get; }
+
+        public AuthenticationContext(string sessionToken, long secretKey, string time)
+        {
+            if (string.IsNullOrEmpty(sessionToken))
+                throw new ArgumentNullException("sessionToken");
+            if (string.IsNullOrEmpty(time))
+                throw new ArgumentNullException("time");
+
+            SessionToken = sessionToken;
+            SecretKey = secretKey;
+            Time = time;
+        }
+    }
+}

--- a/Source/MediaFireSDK/Core/IMediaFireUploadApi.cs
+++ b/Source/MediaFireSDK/Core/IMediaFireUploadApi.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaFireSDK.Model;
-using MediaFireSDK.Model.Responses;
 
 namespace MediaFireSDK.Core
 {
@@ -26,13 +22,7 @@ namespace MediaFireSDK.Core
         /// <param name="folderKey">The destination folder to store the file. If it's not passed, then the file will be stored in the root folder.</param>
         /// <param name="actionOnDuplicate">Specifies the action to take when the file already exists, by name, in the destination folder. skip ignores the upload, keep uploads the file and makes the file name unique by appending a number to it, and replace overwrites the old file, possibly adding to its version history.</param>
         /// <param name="modificationTime">The date/time of the update. If not set, the current server time will be used.</param>
-        Task<MediaFireUploadConfiguration> GetUploadConfiguration(
-            string fileName,
-            long size,
-            string folderKey = null,
-            MediaFireActionOnDuplicate actionOnDuplicate = MediaFireActionOnDuplicate.Keep,
-            DateTime? modificationTime = null
-            );
+        Task<MediaFireUploadConfiguration> GetUploadConfiguration(string fileName, long size, string folderKey = null, MediaFireActionOnDuplicate actionOnDuplicate = MediaFireActionOnDuplicate.Keep, DateTime? modificationTime = null);
 
         /// <summary>
         /// Returns the upload info, of an upload performed outside the sdk.
@@ -50,14 +40,7 @@ namespace MediaFireSDK.Core
         /// <param name="folderKey">The destination folder to store the file. If it's not passed, then the file will be stored in the root folder.</param>
         /// <param name="resumable">Specifies whether to make this upload resumable or not.</param>
         /// <returns></returns>
-        Task<MediaFireUploadCheckDetails> Check(
-            string fileName,
-            long size = 0,
-            string deviceId = null,
-            string hash = null,
-            string folderKey = null,
-            bool resumable = false
-            );
+        Task<MediaFireUploadCheckDetails> Check(string fileName, long size = 0, string deviceId = null, string hash = null, string folderKey = null, bool resumable = false);
 
         /// <summary>
         /// Uploads <paramref name="content"/> to MediaFire given a <paramref name="uploadConfiguration"/> retrieved from GetUploadConfiguration.
@@ -67,12 +50,6 @@ namespace MediaFireSDK.Core
         /// <param name="progress">A callback to receive progress updates.</param>
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <returns></returns>
-        Task<MediaFireUploadDetails> Simple(
-            MediaFireUploadConfiguration uploadConfiguration,
-            Stream content,
-            IProgress<MediaFireOperationProgress> progress = null,
-            CancellationToken? token = null
-            );
-
+        Task<MediaFireUploadDetails> Simple(MediaFireUploadConfiguration uploadConfiguration, Stream content, IProgress<MediaFireOperationProgress> progress = null, CancellationToken? token = null);
     }
 }

--- a/Source/MediaFireSDK/Core/IMediaFireUserApi.cs
+++ b/Source/MediaFireSDK/Core/IMediaFireUserApi.cs
@@ -1,5 +1,5 @@
-﻿using System.Threading.Tasks;
-using MediaFireSDK.Model;
+﻿using System;
+using System.Threading.Tasks;
 using MediaFireSDK.Model.Responses;
 
 namespace MediaFireSDK.Core
@@ -7,13 +7,14 @@ namespace MediaFireSDK.Core
     public interface IMediaFireUserApi
     {
         /// <summary>
-        /// Authenticates the SDK with the user credentials. 
+        /// Authenticates the SDK with the user credentials.
         /// </summary>
         /// <param name="email">The email address of the user's MediaFire account.</param>
         /// <param name="password">The password of the user's MediaFire account.</param>
+        /// <param name="tokenVersion">The <see cref="TokenVersion"/> to retrieve.</param>
         /// <returns>The user session token</returns>
         /// <remarks>This method is not thread-safe.</remarks>
-        Task<string> GetSessionToken(string email, string password);
+        Task<string> GetSessionToken(string email, string password, TokenVersion tokenVersion = TokenVersion.V1);
 
         /// <summary>
         /// Register an individual with MediaFire and create a user account.
@@ -26,13 +27,25 @@ namespace MediaFireSDK.Core
         Task<RegisterResponse> Register(string email, string password, string firstName = null, string lastName = null, string displayName = null);
 
         /// <summary>
-        /// Returns the HTML format of the MediaFire Terms of Service and its revision number, date, whether the user has accepted it not not, and the acceptance token (if the user has not accepted the latest terms). 
+        /// Gets the session token v2 and associated secret key and time.
+        /// </summary>
+        /// <returns>The authentication context.</returns>
+        AuthenticationContext GetAuthenticationContext();
+
+        /// <summary>
+        /// Sets the session token v2 and associated secret key and time.
+        /// </summary>
+        /// <param name="authenticationContext">The authentication context.</param>
+        void SetAuthenticationContext(AuthenticationContext authenticationContext);
+
+        /// <summary>
+        /// Returns the HTML format of the MediaFire Terms of Service and its revision number, date, whether the user has accepted it not not, and the acceptance token (if the user has not accepted the latest terms).
         /// </summary>
         /// <returns>An object with the necessary info about the terms of service </returns>
         Task<UserTermsOfService> FetchTermsOfService();
 
         /// <summary>
-        /// Records that the session user has accepted the MediaFire Terms of Service by sending the acceptance token. 
+        /// Records that the session user has accepted the MediaFire Terms of Service by sending the acceptance token.
         /// </summary>
         /// <param name="acceptanceToken">The token returned by FetchTermsOfService.</param>
         Task AcceptTermsOfService(string acceptanceToken);
@@ -41,5 +54,10 @@ namespace MediaFireSDK.Core
         /// Removes from the SDK all user information.
         /// </summary>
         Task Logout();
+
+        /// <summary>
+        /// Occurs when the authentication context changed.
+        /// </summary>
+        event EventHandler AuthenticationContextChanged;
     }
 }

--- a/Source/MediaFireSDK/Core/MediaFireApiBase.cs
+++ b/Source/MediaFireSDK/Core/MediaFireApiBase.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using MediaFireSDK.Http;
 using MediaFireSDK.Model;
@@ -13,8 +8,9 @@ namespace MediaFireSDK.Core
 {
     internal abstract class MediaFireApiBase
     {
-        protected MediaFireApiConfiguration Configuration { get; private set; }
-        protected MediaFireRequestController RequestController { get; private set; }
+        protected MediaFireApiConfiguration Configuration { get; }
+
+        protected MediaFireRequestController RequestController { get; }
 
         protected MediaFireApiBase(MediaFireRequestController requestController)
         {
@@ -27,16 +23,16 @@ namespace MediaFireSDK.Core
             RequestController = requestController;
         }
 
-        public async Task<T> Post<T>(string path, bool authenticate = true) where T : MediaFireResponseBase
+        public async Task<T> Post<T>(string path, bool authenticate = true)
+            where T : MediaFireResponseBase
         {
-            return await RequestController.Post<T>(await RequestController.CreateHttpRequest(path, authenticate));
+            return await RequestController.Post<T>(await RequestController.CreateHttpRequest(path, authenticate: authenticate));
         }
 
-        public async Task<T> Get<T>(string path, bool authenticate = true) where T : MediaFireResponseBase
+        public async Task<T> Get<T>(string path, bool authenticate = true)
+            where T : MediaFireResponseBase
         {
-            return await RequestController.Get<T>(await RequestController.CreateHttpRequest(path, authenticate));
+            return await RequestController.Get<T>(await RequestController.CreateHttpRequest(path, authenticate: authenticate));
         }
-
-      
     }
 }

--- a/Source/MediaFireSDK/Core/TokenVersion.cs
+++ b/Source/MediaFireSDK/Core/TokenVersion.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace MediaFireSDK.Core
+{
+    public enum TokenVersion
+    {
+        V1,
+        V2
+    }
+}

--- a/Source/MediaFireSDK/Http/HttpClientAgent.cs
+++ b/Source/MediaFireSDK/Http/HttpClientAgent.cs
@@ -1,15 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaFireSDK.Http.Error;
 using MediaFireSDK.Model;
-using Newtonsoft.Json;
 
 namespace MediaFireSDK.Http
 {
@@ -21,12 +17,7 @@ namespace MediaFireSDK.Http
         private readonly int _bufferSize;
         private readonly CancellationToken _token;
 
-        public UploadWithProgressHttpContent(
-            IProgress<MediaFireOperationProgress> progress,
-            MediaFireOperationProgress data,
-            Stream file,
-            int bufferSize,
-            CancellationToken token)
+        public UploadWithProgressHttpContent(IProgress<MediaFireOperationProgress> progress, MediaFireOperationProgress data, Stream file, int bufferSize, CancellationToken token)
         {
             _progress = progress;
             _data = data;
@@ -34,8 +25,6 @@ namespace MediaFireSDK.Http
             _bufferSize = bufferSize;
             _token = token;
         }
-
-
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
@@ -61,12 +50,9 @@ namespace MediaFireSDK.Http
             _useHttpV1 = useHttpV1;
         }
 
-
         public async override Task<T> SendAsync<T>(HttpMethod method)
         {
-
             var handler = new HttpClientHandler();
-
 
             var cli = new HttpClient(handler);
 
@@ -82,7 +68,6 @@ namespace MediaFireSDK.Http
                 content = new UploadWithProgressHttpContent(ProgressOperation, ProgressData, Stream, _chunkBufferSize, Token);
             }
 
-
             if ((Parameters.Count != 0) && (content != null || method != HttpMethod.Post))
                 Path = MediaFireHttpHelpers.BuildQueryString(Parameters, Path);
             else
@@ -95,8 +80,6 @@ namespace MediaFireSDK.Http
                 content = parameters;
             }
 
-
-
             var req = new HttpRequestMessage(method, Path) { Content = content };
 
             if (content != null)
@@ -107,7 +90,6 @@ namespace MediaFireSDK.Http
                 }
 
                 req.Content = content;
-
             }
 
             //
@@ -115,7 +97,6 @@ namespace MediaFireSDK.Http
             //
             if (IsUpload && _useHttpV1)
                 req.Version = new Version(1, 0);
-
 
             var completionOption = HttpCompletionOption.ResponseContentRead;
 
@@ -128,7 +109,6 @@ namespace MediaFireSDK.Http
             {
                 await DownloadToStream(resp);
                 return default(T);
-
             }
 
             return await DeserializeObject<T>(resp);
@@ -158,10 +138,7 @@ namespace MediaFireSDK.Http
                 throw new HttpRequestExtendedException(resp, e, resultString);
             }
 
-
             return DeserializeJson<T>(resultString);
         }
-
-       
     }
 }

--- a/Source/MediaFireSDK/IMediaFireAgent.cs
+++ b/Source/MediaFireSDK/IMediaFireAgent.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaFireSDK.Core;
 using MediaFireSDK.Model;
 using MediaFireSDK.Model.Responses;
 using MediaFireSDK.Multimedia;
-using Org.BouncyCastle.Bcpg;
 
 namespace MediaFireSDK
 {
@@ -30,12 +27,12 @@ namespace MediaFireSDK
 
         /// <summary>
         /// The Image api methods.
-        /// </summary>        
+        /// </summary>
         IMediaFireImageApi Image { get; }
 
         /// <summary>
         /// The Upload api methods.
-        /// </summary>        
+        /// </summary>
         IMediaFireUploadApi Upload { get; }
 
         /// <summary>
@@ -47,9 +44,10 @@ namespace MediaFireSDK
         /// <param name="attachSessionToken">Lets the SDK know if it is required to authenticate the request.</param>
         /// <returns>A deserialized response of type T</returns>
         /// <example>
-        /// 
+        ///
         /// </example>
-        Task<T> GetAsync<T>(string path, IDictionary<string, object> parameters = null, bool attachSessionToken = true) where T : MediaFireResponseBase;
+        Task<T> GetAsync<T>(string path, IDictionary<string, object> parameters = null, bool attachSessionToken = true)
+            where T : MediaFireResponseBase;
 
         /// <summary>
         /// Performs a Http Post to the MediaFire API.
@@ -60,9 +58,10 @@ namespace MediaFireSDK
         /// <param name="attachSessionToken">Lets the SDK know if it is required to authenticate the request.</param>
         /// <returns>A deserialized response of type T</returns>
         /// <example>
-        /// 
+        ///
         /// </example>
-        Task<T> PostAsync<T>(string path, IDictionary<string, object> parameters = null, bool attachSessionToken = true) where T : MediaFireResponseBase;
+        Task<T> PostAsync<T>(string path, IDictionary<string, object> parameters = null, bool attachSessionToken = true)
+            where T : MediaFireResponseBase;
 
         /// <summary>
         /// Performs a Http Post to the MediaFire API, of a file.
@@ -76,15 +75,8 @@ namespace MediaFireSDK
         /// <param name="token">The token to monitor for cancellation requests.</param>
         /// <param name="progress">A callback to receive progress updates.</param>
         /// <returns>A deserialized response of type T</returns>
-        Task<T> PostStreamAsync<T>(
-            string path, 
-            Stream content, 
-            IDictionary<string, object> parameters, 
-            IDictionary<string, string> headers, 
-            bool attachSessionToken = true,
-            CancellationToken? token = null,
-            IProgress<MediaFireOperationProgress> progress = null 
-            ) where T : MediaFireResponseBase;
-
+        Task<T> PostStreamAsync<T>(string path, Stream content, IDictionary<string, object> parameters, IDictionary<string, string> headers, bool attachSessionToken = true,
+                                   CancellationToken? token = null, IProgress<MediaFireOperationProgress> progress = null)
+            where T : MediaFireResponseBase;
     }
 }

--- a/Source/MediaFireSDK/MediaFireConstants.cs
+++ b/Source/MediaFireSDK/MediaFireConstants.cs
@@ -1,6 +1,5 @@
 ﻿namespace MediaFireSDK
 {
-
     /// Core Api Contants
     public static class MediaFireApiConstants
     {
@@ -21,14 +20,12 @@
         public const string LinkTypeWatch = "watch";
         public const string LinkTypeStreaming = "streaming";
 
-
         public const string MediaFireFile = "file";
         public const string MediaFireFolder = "folder";
 
         public const string ContentTypeHeader = "Content-Type";
         public const string SimpleUploadContentTypeValue = "application/octet-stream";
         public const string ResumableUploadContentTypeValue = SimpleUploadContentTypeValue;
-
 
         public const string FileNameHeader = "x-filename";
         public const string FileSizeHeader = "x-filesize";
@@ -37,8 +34,6 @@
         public const string UnitIdHeader = "x-unit-id";
         public const string UnitSizeHeader = "x-unit-size";
         public const string UnitHashHeader = "x-unit-hash";
-
-
 
         public const string UserAcceptedTermsValue = MediaFireYes;
 
@@ -49,9 +44,9 @@
         public const string PrivatePrivacy = "private";
     }
 
-    /// 
+    ///
     /// Api Methods contants.
-    /// 
+    ///
 
     public static class MediaFireApiBillingMethods
     {
@@ -62,7 +57,6 @@
         public const string GetPlans = BillingMethodsPath + "get_plans.php";
         public const string GetProducts = BillingMethodsPath + "get_products.php";
         public const string PurchasePlan = BillingMethodsPath + "purchase_plan.php";
-
     }
 
     public static class MediaFireApiContactMethods
@@ -79,7 +73,6 @@
 
     public static class MediaFireApiDeviceMethods
     {
-
         public const string DeviceMethodsPath = "device/";
         public const string AddDevice = DeviceMethodsPath + "add_device.php";
         public const string EmptyTrash = DeviceMethodsPath + "empty_trash.php";
@@ -102,7 +95,6 @@
 
     public static class MediaFireApiFileMethods
     {
-
         public const string FileMethodsPath = "file/";
         public const string ConfigureOneTimeKey = FileMethodsPath + "configure_one_time_key.php";
         public const string Copy = FileMethodsPath + "copy.php";
@@ -122,10 +114,8 @@
         public const string Zip = FileMethodsPath + "zip.php";
     }
 
-
     public static class MediaFireApiFolderMethods
     {
-
         public const string FolderMethodsPath = "folder/";
         public const string ConfigureFiledrop = FolderMethodsPath + "configure_filedrop.php";
         public const string Copy = FolderMethodsPath + "copy.php";
@@ -143,14 +133,12 @@
 
     public static class MediaFireApiNotificationsMethods
     {
-
         public const string NotificationsMethodsPath = "notifications/";
         public const string GetCache = NotificationsMethodsPath + "get_cache.php";
         public const string PeekCache = NotificationsMethodsPath + "peek_cache.php";
         public const string SendMessage = NotificationsMethodsPath + "send_message.php";
         public const string SendNotification = NotificationsMethodsPath + "send_notification.php";
     }
-
 
     public static class MediaFireApiSystemMethods
     {
@@ -197,21 +185,14 @@
         public const string SetAvatar = UserMethodsPath + "set_avatar.php";
         public const string SetSettings = UserMethodsPath + "set_settings.php";
         public const string Update = UserMethodsPath + "update.php";
-
     }
-
-
-
-
-
-
-
 
     public static class MediaFireApiParameters
     {
         public const string Signature = "signature";
         public const string ResponseFormat = "response_format";
         public const string SessionToken = "session_token";
+        public const string TokenVersion = "token_version";
         public const string AppId = "application_id";
         public const string Password = "password";
         public const string Email = "email";
@@ -220,7 +201,7 @@
         public const string Description = "description";
         public const string Truncate = "truncate";
         public const string ParentKey = "parent_key";
-        public const string ActionOnDuplicate = "action_on_duplicate ";
+        public const string ActionOnDuplicate = "action_on_duplicate";
         public const string Key = "key";
         public const string ContentType = "content_type";
         public const string ContentTypeFileType = "files";
@@ -229,7 +210,9 @@
         public const string FolderKey = "folder_key";
         public const string FolderKeySource = "folder_key_src";
         public const string FolderKeyDestination = "folder_key_dst";
+        public const string FolderPath = "folder_path";
         public const string QuickKey = "quick_key";
+        public const string FilePath = "file_path";
         public const string SearchText = "search_text";
         public const string FirstName = "first_name";
         public const string LastName = "last_name";
@@ -245,7 +228,6 @@
         public const string ChunkSize = "chunk_size";
         public const string Details = "details";
         public const string LinkType = "link_type";
-
 
         public const string ModificationTime = "mtime";
         public const string Privacy = "privacy";
@@ -441,6 +423,5 @@
         public const int UnkownList = 255;
         public const int InvalidImportService = 256;
         public const int CardReuseForbidden = 257;
-
     }
 }

--- a/Source/MediaFireSDK/MediaFireExtensions.cs
+++ b/Source/MediaFireSDK/MediaFireExtensions.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MediaFireSDK.Model;
 
 namespace MediaFireSDK
@@ -24,7 +20,7 @@ namespace MediaFireSDK
         /// <param name="value">yes or no strings</param>
         public static string ToMediaFireYesNo(this bool? value)
         {
-            return value == null ? String.Empty : value.Value.ToMediaFireYesNo();
+            return value == null ? string.Empty : value.Value.ToMediaFireYesNo();
         }
 
         /// <summary>
@@ -65,32 +61,40 @@ namespace MediaFireSDK
         /// <param name="linkType">The parameter to be converted.</param>
         public static string ToApiParameter(this MediaFireLinkType linkType)
         {
-            var type = String.Empty;
+            var type = string.Empty;
             switch (linkType)
             {
                 case MediaFireLinkType.DirectDownload:
                     type = MediaFireApiConstants.LinkTypeDirectDownload;
                     break;
+
                 case MediaFireLinkType.Edit:
                     type = MediaFireApiConstants.LinkTypeEdit;
                     break;
+
                 case MediaFireLinkType.Listen:
                     type = MediaFireApiConstants.LinkTypeListen;
                     break;
+
                 case MediaFireLinkType.NormalDownload:
                     type = MediaFireApiConstants.LinkTypeNormalDownload;
                     break;
+
                 case MediaFireLinkType.OneTimeDownload:
                     type = MediaFireApiConstants.LinkTypeOneTimeDownload;
                     break;
+
                 case MediaFireLinkType.Streaming:
                     type = MediaFireApiConstants.LinkTypeStreaming;
                     break;
+
                 case MediaFireLinkType.View:
                     type = MediaFireApiConstants.LinkTypeView;
                     break;
+
                 case MediaFireLinkType.All:
                     break;
+
                 default:
                     throw new InvalidOperationException();
             }
@@ -105,7 +109,6 @@ namespace MediaFireSDK
                 : MediaFireApiParameters.ContentTypeFolderType;
         }
 
-        
         public static string ToApiParameter(this MediaFireContentFilter[] filters)
         {
             if (filters == null || filters.Length == 0)
@@ -123,6 +126,5 @@ namespace MediaFireSDK
         {
             return query.ToString().ToLower();
         }
-
     }
 }

--- a/Source/MediaFireSDK/MediaFireSDK.csproj
+++ b/Source/MediaFireSDK/MediaFireSDK.csproj
@@ -17,6 +17,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Source\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -41,6 +43,8 @@
     <Compile Include="Core\MediaFireSessionBroker.cs" />
     <Compile Include="Core\MediaFireUploadApi.cs" />
     <Compile Include="Core\MediaFireUserApi.cs" />
+    <Compile Include="Core\AuthenticationContext.cs" />
+    <Compile Include="Core\TokenVersion.cs" />
     <Compile Include="Http\HttpClientAgent.cs" />
     <Compile Include="MediaFireExtensions.cs" />
     <Compile Include="Model\Errors\MediaFireApiException.cs" />
@@ -76,51 +80,38 @@
     <Compile Include="Services\ICryptoService.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="crypto, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Portable.BouncyCastle.1.7.0.2\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\crypto.dll</HintPath>
+    <Reference Include="crypto">
+      <HintPath>..\packages\Portable.BouncyCastle.1.8.1\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Extensions, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Formatting">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=1.5.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Source/MediaFireSDK/Model/MediaFireApiConfiguration.cs
+++ b/Source/MediaFireSDK/Model/MediaFireApiConfiguration.cs
@@ -10,43 +10,42 @@ namespace MediaFireSDK.Model
         /// <summary>
         /// The aplication key.
         /// </summary>
-        public string ApiKey { get; private set; }
+        public string ApiKey { get; }
 
         /// <summary>
         /// The aplication id.
         /// </summary>
-        public string AppId { get; private set; }
+        public string AppId { get; }
 
         /// <summary>
         /// The api version to be used by the sdk.
         /// </summary>
-        public string ApiVersion { get; private set; }
+        public string ApiVersion { get; }
 
         /// <summary>
         /// Configures the sdk to automatically renew the client if the session token expires.
         /// </summary>
-        public bool AutomaticallyRenewToken { get; private set; }
+        public bool AutomaticallyRenewToken { get; }
 
         /// <summary>
         /// The buffer size to be used on block operations, upload and download.
         /// </summary>
-        public int ChunkTransferBufferSize { get; private set; }
+        public int ChunkTransferBufferSize { get; }
 
         /// <summary>
         /// Use version 1.0 of http
         /// <remarks>On some platforms, the client will throw the error "The server committed a protocol violation. Section=ResponseStatusLine". In that cases set this property to true</remarks>
         /// </summary>
-        public bool UseHttpV1 { get; private set; }
+        public bool UseHttpV1 { get; }
 
         /// <summary>
-        /// Configures a timer so that every SessionRenewPeriod minutes the SDK can renew automatically the session. 
+        /// Configures a timer so that every SessionRenewPeriod minutes the SDK can renew automatically the session.
         /// </summary>
-        public bool PeriodicallyRenewToken { get; private set; }
+        public bool PeriodicallyRenewToken { get; }
 
         public TimeSpan SessionRenewPeriod { get; set; }
 
-
-        public MediaFireApiConfiguration(string apiKey, string appId, string apiVersion = "1.4", bool automaticallyRenewToken = true, int chunkTransferBufferSize = 4096, bool useHttpV1 = false, bool periodicallyRenewToken = false)
+        public MediaFireApiConfiguration(string apiKey, string appId, string apiVersion = "1.5", bool automaticallyRenewToken = true, int chunkTransferBufferSize = 4096, bool useHttpV1 = false, bool periodicallyRenewToken = false)
         {
             ApiKey = apiKey;
             AppId = appId;

--- a/Source/MediaFireSDK/Model/Responses/FileResponses.cs
+++ b/Source/MediaFireSDK/Model/Responses/FileResponses.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
@@ -16,12 +12,16 @@ namespace MediaFireSDK.Model.Responses
     public class MediaFireGetLinksResponse : MediaFireResponseBase
     {
         public MediaFireLinks[] Links { get; set; }
+
         [JsonProperty("one_time_download_request_count")]
         public int OneTimeDownloadRequestCount { get; set; }
+
         [JsonProperty("direct_download_free_bandwidth")]
         public int DirectDownloadFreeBandwidth { get; set; }
+
         [JsonProperty("one_time_key_request_count")]
         public int OneTimeKeyRequestCount { get; set; }
+
         [JsonProperty("one_time_key_request_max_count")]
         public int OneTimeKeyRequestMaxCount { get; set; }
     }

--- a/Source/MediaFireSDK/Model/Responses/FolderResponses.cs
+++ b/Source/MediaFireSDK/Model/Responses/FolderResponses.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
@@ -15,6 +11,7 @@ namespace MediaFireSDK.Model.Responses
 
     public class MediaFireCreateFolderResponse : MediaFireResponseBase
     {
+        [JsonProperty("folder_key")]
         public string FolderKey { get; set; }
     }
 
@@ -27,35 +24,57 @@ namespace MediaFireSDK.Model.Responses
     public class MediaFireSearchResultItem
     {
         public string Type { get; set; }
-        public string QuickKey { get; set; }
+
+        public string Quickkey { get; set; }
+
         public string FileName { get; set; }
+
         [JsonProperty("parent_folderkey")]
         public string ParentFolderkey { get; set; }
+
         [JsonProperty("parent_name")]
         public string ParentName { get; set; }
+
         public DateTime Created { get; set; }
+
         public string Revision { get; set; }
+
         public long Size { get; set; }
+
         public string Description { get; set; }
+
         public string Privacy { get; set; }
+
         [JsonProperty("password_protected")]
         public string PasswordProtected { get; set; }
+
         public string MimeType { get; set; }
+
         public string FileType { get; set; }
+
         public int View { get; set; }
+
         public int Edit { get; set; }
+
         public string Hash { get; set; }
+
         public string Flag { get; set; }
+
         public int Relevancy { get; set; }
+
         [JsonProperty("created_utc")]
         public DateTime CreatedUtc { get; set; }
+
         public string FolderKey { get; set; }
+
         public string Name { get; set; }
 
         [JsonProperty("total_folders")]
         public int TotalFolders { get; set; }
+
         [JsonProperty("total_files")]
         public int TotalFiles { get; set; }
+
         [JsonProperty("total_size")]
         public long TotalSize { get; set; }
     }
@@ -64,6 +83,7 @@ namespace MediaFireSDK.Model.Responses
     {
         [JsonProperty("results_count")]
         public int ResultsCount { get; set; }
+
         public MediaFireSearchResultItem[] Results { get; set; }
     }
 }

--- a/Source/MediaFireSDK/Model/Responses/GenericResponse.cs
+++ b/Source/MediaFireSDK/Model/Responses/GenericResponse.cs
@@ -1,25 +1,31 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
 {
-
     public abstract class MediaFireResponseBase
     {
         public string Action { get; set; }
+
         public string PKey { get; set; }
+
         public string Message { get; set; }
+
         public int Error { get; set; }
+
         public string Result { get; set; }
 
         [JsonProperty("current_api_version")]
         public string CurrentApiVersion { get; set; }
+
         public string Deprecated { get; set; }
+
         public string Asynchronous { get; set; }
+
+        [JsonProperty("new_key")]
+        internal string NewKeyInternal { get; set; }
+
+        public bool NewKey { get { return !string.IsNullOrEmpty(NewKeyInternal) &&  NewKeyInternal.FromMediaFireYesNo(); } }
     }
 
     internal class MediaFireResponseContainer<T> where T : MediaFireResponseBase
@@ -27,7 +33,11 @@ namespace MediaFireSDK.Model.Responses
         public T Response { get; set; }
     }
 
+    public class MediaFireEmptyResponse : MediaFireResponseBase
+    {
+    }
 
-    public class MediaFireEmptyResponse : MediaFireResponseBase { }
-    public class MediaFireErrorResponse : MediaFireResponseBase { }
+    public class MediaFireErrorResponse : MediaFireResponseBase
+    {
+    }
 }

--- a/Source/MediaFireSDK/Model/Responses/MediaFireTermsOfService.cs
+++ b/Source/MediaFireSDK/Model/Responses/MediaFireTermsOfService.cs
@@ -1,17 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
 {
-
     public class MediaFireTermsOfService
     {
         public string Revision { get; set; }
+
         public string Terms { get; set; }
+
         public DateTime Date { get; set; }
     }
 
@@ -19,17 +16,10 @@ namespace MediaFireSDK.Model.Responses
     {
         [JsonProperty("user_accepted_terms")]
         internal string UserAcceptedTermsString { get; set; }
-        public bool UserAcceptedTerms
-        {
-            get
-            {
-                return UserAcceptedTermsString.Equals(MediaFireApiConstants.MediaFireNo, StringComparison.OrdinalIgnoreCase);
-            }
-        }
+
+        public bool UserAcceptedTerms { get { return UserAcceptedTermsString.FromMediaFireYesNo(); } }
 
         [JsonProperty("acceptance_token")]
         public string AcceptanceToken { get; set; }
     }
-
-   
 }

--- a/Source/MediaFireSDK/Model/Responses/UploadResponses.cs
+++ b/Source/MediaFireSDK/Model/Responses/UploadResponses.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
@@ -13,13 +10,12 @@ namespace MediaFireSDK.Model.Responses
 
         [JsonProperty("resumable_upload")]
         public ResumableUploadDetails ResumableUpload { get; set; }
-
-      
     }
 
     public class Bitmap
     {
         public int Count { get; set; }
+
         public List<int> Words { get; set; }
     }
 
@@ -27,15 +23,15 @@ namespace MediaFireSDK.Model.Responses
     {
         [JsonProperty("all_units_ready")]
         internal string AllUnitsReadyInternal { get; set; }
-        
+
         public bool AllUnitsReady { get { return AllUnitsReadyInternal.FromMediaFireYesNo(); } }
-        
+
         [JsonProperty("number_of_units")]
         public int NumberOfUnits { get; set; }
-        
+
         [JsonProperty("unit_size")]
         public long UnitSize { get; set; }
+
         public Bitmap Bitmap { get; set; }
     }
-
 }

--- a/Source/MediaFireSDK/Model/Responses/UserResponses.cs
+++ b/Source/MediaFireSDK/Model/Responses/UserResponses.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace MediaFireSDK.Model.Responses
@@ -11,17 +7,18 @@ namespace MediaFireSDK.Model.Responses
     {
         [JsonProperty("session_token")]
         public string SessionToken { get; set; }
-    }
 
+        [JsonProperty("secret_key")]
+        public string SecretKey { get; set; }
+
+        public string Time { get; set; }
+    }
 
     public class MediaFireGetUserInfoResponse : MediaFireResponseBase
     {
         [JsonProperty("user_info")]
         public MediaFireUserDetails UserDetails { get; set; }
     }
-
-
-
 
     internal class FetchTosResponse : MediaFireResponseBase
     {
@@ -38,5 +35,4 @@ namespace MediaFireSDK.Model.Responses
         [JsonProperty("created_utc")]
         public DateTime CreatedUtc { get; set; }
     }
-
 }

--- a/Source/MediaFireSDK/Properties/AssemblyInfo.cs
+++ b/Source/MediaFireSDK/Properties/AssemblyInfo.cs
@@ -1,9 +1,7 @@
-﻿using System.Resources;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Reflection;
+using System.Resources;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("MediaFireSDK.Portable")]
@@ -19,11 +17,11 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.2")]

--- a/Source/MediaFireSDK/Services/BouncyCastleCryptoService.cs
+++ b/Source/MediaFireSDK/Services/BouncyCastleCryptoService.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Digests;
 
@@ -10,12 +7,17 @@ namespace MediaFireSDK.Services
 {
     internal class BouncyCastleCryptoService : ICryptoService
     {
+        public string GetMd5Hash(string s)
+        {
+            return GetHash(s, new MD5Digest());
+        }
+
         public string GetSha1Hash(string s)
         {
             return GetHash(s, new Sha1Digest());
         }
 
-        private string GetHash(string s, IDigest algorithm)
+        private static string GetHash(string s, IDigest algorithm)
         {
             var bytes = Encoding.UTF8.GetBytes(s);
             algorithm.BlockUpdate(bytes,0,bytes.Length);

--- a/Source/MediaFireSDK/Services/ICryptoService.cs
+++ b/Source/MediaFireSDK/Services/ICryptoService.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MediaFireSDK.Services
 {
-   internal interface ICryptoService
-   {
-       string GetSha1Hash(string s);
-   }
+    internal interface ICryptoService
+    {
+        string GetMd5Hash(string s);
+
+        string GetSha1Hash(string s);
+    }
 }

--- a/Source/MediaFireSDK/app.config
+++ b/Source/MediaFireSDK/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Source/MediaFireSDK/packages.config
+++ b/Source/MediaFireSDK/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
-  <package id="Portable.BouncyCastle" version="1.7.0.2" targetFramework="portable-net45+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="Portable.BouncyCastle" version="1.8.1" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
without explicit user login
- Added implementation for MediaFire SessionToken V2 / Call Signatures
- Added unit test project
- Updated default MediaFire API version to "1.5"
- Various bugfixes in HTTP request assembly
- Updated dependencies: Newtonsoft.Json to version 9.0.1, Portable.BouncyCastle to version 1.8.1, Microsoft.Net.Http to version 2.2.29
- Removed obsolete NuGet configuration
- Minor code cleanup